### PR TITLE
fix(Parser): require at least 2 conditions for AND/OR filters

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -76,6 +76,10 @@ class Parser
             $conditions[] = $this->parseExpression();
         }
 
+        if (\count($conditions) < 2) {
+            $this->syntaxError('AND filter requires at least 2 conditions');
+        }
+
         return new AndNode($conditions);
     }
 
@@ -89,6 +93,10 @@ class Parser
 
         while (!$this->lexer->isNextToken(Lexer::RPAREN)) {
             $conditions[] = $this->parseExpression();
+        }
+
+        if (\count($conditions) < 2) {
+            $this->syntaxError('OR filter requires at least 2 conditions');
         }
 
         return new OrNode($conditions);

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -73,4 +73,36 @@ class ParserTest extends TestCase
         yield 'leading space after lparen' => ['( attr=value)'];
         yield 'spaces on both sides' => ['(attr = value)'];
     }
+
+    /** @dataProvider insufficientConditionsProvider */
+    public function testParserRejectsAndOrWithLessThanTwoConditions(string $filter): void
+    {
+        $this->expectException(FilterException::class);
+
+        (new Parser(new Filter($filter)))->getAST();
+    }
+
+    public static function insufficientConditionsProvider(): \Generator
+    {
+        yield 'AND with zero conditions' => ['(&)'];
+        yield 'AND with one condition' => ['(&(cn=value))'];
+        yield 'OR with zero conditions' => ['(|)'];
+        yield 'OR with one condition' => ['(|(cn=value))'];
+    }
+
+    /** @dataProvider validMultipleConditionsProvider */
+    public function testParserAcceptsAndOrWithTwoOrMoreConditions(string $filter): void
+    {
+        $ast = (new Parser(new Filter($filter)))->getAST();
+
+        $this->assertNotNull($ast);
+    }
+
+    public static function validMultipleConditionsProvider(): \Generator
+    {
+        yield 'AND with two conditions' => ['(&(cn=a)(sn=b))'];
+        yield 'AND with three conditions' => ['(&(cn=a)(sn=b)(uid=c))'];
+        yield 'OR with two conditions' => ['(|(cn=a)(sn=b))'];
+        yield 'OR with three conditions' => ['(|(cn=a)(sn=b)(uid=c))'];
+    }
 }


### PR DESCRIPTION
RFC 4515 mandates a minimum of 2 operands for & and | operators. Accepting 0 or 1 condition produced a structurally invalid AST silently.