### PR TITLE
fix(FilterBuilder): include current expression when chaining andX/orX…

### DIFF
--- a/src/FilterBuilder.php
+++ b/src/FilterBuilder.php
@@ -51,6 +51,10 @@ class FilterBuilder
     {
         $expressions = $this->processExpressions(...$x);
 
+        if (null !== $this->expression) {
+            array_unshift($expressions, $this->expression);
+        }
+
         return new self(new Expression\AndX(...$expressions));
     }
 
@@ -58,12 +62,22 @@ class FilterBuilder
     {
         $expressions = $this->processExpressions(...$x);
 
+        if (null !== $this->expression) {
+            array_unshift($expressions, $this->expression);
+        }
+
         return new self(new Expression\OrX(...$expressions));
     }
 
-    public function not(self|Expression\Base $not): self
+    public function not(self|Expression\Base|null $not = null): self
     {
-        $expression = $this->processExpressions($not)[0];
+        $expression = null !== $not
+            ? $this->processExpressions($not)[0]
+            : $this->expression;
+
+        if (null === $expression) {
+            throw new \InvalidArgumentException('Expression cannot be null');
+        }
 
         return new self(new Expression\Not($expression));
     }

--- a/tests/FilterBuilderTest.php
+++ b/tests/FilterBuilderTest.php
@@ -101,4 +101,41 @@ class FilterBuilderTest extends TestCase
             FilterBuilder::create()
         );
     }
+
+    public function testAndXChaining(): void
+    {
+        $filter = FilterBuilder::create()
+            ->equals('cn', 'Jensen')
+            ->andX(FilterBuilder::create()->equals('uid', 'bJensen'))
+            ->getFilter();
+
+        $this->assertSame('(&(cn=Jensen)(uid=bJensen))', (string) $filter);
+    }
+
+    public function testOrXChaining(): void
+    {
+        $filter = FilterBuilder::create()
+            ->equals('cn', 'Jensen')
+            ->orX(FilterBuilder::create()->equals('uid', 'bJensen'))
+            ->getFilter();
+
+        $this->assertSame('(|(cn=Jensen)(uid=bJensen))', (string) $filter);
+    }
+
+    public function testNotChainingWithoutArgument(): void
+    {
+        $filter = FilterBuilder::create()
+            ->equals('uid', 'bJensen')
+            ->not()
+            ->getFilter();
+
+        $this->assertSame('(!(uid=bJensen))', (string) $filter);
+    }
+
+    public function testNotThrowsWhenNoExpressionAvailable(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+
+        FilterBuilder::create()->not();
+    }
 }


### PR DESCRIPTION
…/not

andX() and orX() now prepend $this->expression to the condition list when set. not() accepts an optional argument and falls back to $this->expression, enabling fluent chaining without silently discarding the builder state.