### PR TITLE
feat(extensible-match): implement RFC 4515 extensible match filter support

### DIFF
--- a/src/AST/ExtensibleNode.php
+++ b/src/AST/ExtensibleNode.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Jvancoillie\LdapFilterLexer\AST;
+
+use Jvancoillie\LdapFilterLexer\Visitor\NodeVisitorInterface;
+use Jvancoillie\LdapFilterLexer\Visitor\VisitableNodeInterface;
+
+class ExtensibleNode extends Node implements VisitableNodeInterface
+{
+    public function __construct(
+        public readonly ?string $attribute,
+        public readonly bool $dnAttributes,
+        public readonly ?string $matchingRule,
+        public readonly AssertionValueNode $assertionValue,
+    ) {
+    }
+
+    public function accept(NodeVisitorInterface $visitor): mixed
+    {
+        return $visitor->visitExtensibleNode($this);
+    }
+}

--- a/src/Expression/ExtensibleMatch.php
+++ b/src/Expression/ExtensibleMatch.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Jvancoillie\LdapFilterLexer\Expression;
+
+class ExtensibleMatch extends Base
+{
+    public function __construct(
+        private readonly ?string $attribute,
+        private readonly bool $dnAttributes,
+        private readonly ?string $matchingRule,
+        private readonly string $value,
+    ) {
+    }
+
+    public function __toString(): string
+    {
+        $filter = $this->leftParenthesis;
+        $filter .= $this->attribute ?? '';
+
+        if ($this->dnAttributes) {
+            $filter .= ':dn';
+        }
+
+        if (null !== $this->matchingRule) {
+            $filter .= ':'.$this->matchingRule;
+        }
+
+        $filter .= ':='.$this->value.$this->rightParenthesis;
+
+        return $filter;
+    }
+}

--- a/src/FilterBuilder.php
+++ b/src/FilterBuilder.php
@@ -69,6 +69,11 @@ class FilterBuilder
         return new self(new Expression\OrX(...$expressions));
     }
 
+    public function extensible(string $value, ?string $attribute = null, ?string $matchingRule = null, bool $dnAttributes = false): self
+    {
+        return new self(new Expression\ExtensibleMatch($attribute, $dnAttributes, $matchingRule, $value));
+    }
+
     public function not(self|Expression\Base|null $not = null): self
     {
         $expression = null !== $not

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -5,6 +5,7 @@ namespace Jvancoillie\LdapFilterLexer;
 use Jvancoillie\LdapFilterLexer\AST\AndNode;
 use Jvancoillie\LdapFilterLexer\AST\AssertionValueNode;
 use Jvancoillie\LdapFilterLexer\AST\AttributeNode;
+use Jvancoillie\LdapFilterLexer\AST\ExtensibleNode;
 use Jvancoillie\LdapFilterLexer\AST\FilterTypeNode;
 use Jvancoillie\LdapFilterLexer\AST\Node;
 use Jvancoillie\LdapFilterLexer\AST\NotNode;
@@ -125,11 +126,59 @@ class Parser
      */
     private function parseFilter(): Node
     {
+        $token = $this->lexer->lookahead->value ?? null;
+
+        if (null !== $token && str_contains($token, ':')) {
+            return $this->parseExtensibleFilter($token);
+        }
+
         $attribute = $this->getAttribute();
         $operator = $this->getOperator();
         $assertionValue = $this->getAssertionValue();
 
         return new SimpleNode($attribute, $operator, $assertionValue);
+    }
+
+    /**
+     * @throws FilterException
+     */
+    private function parseExtensibleFilter(string $token): ExtensibleNode
+    {
+        $this->match(Lexer::ATTRIBUTE_OR_ASSERTION_VALUE);
+        $this->match(Lexer::EQUALS);
+
+        $assertionValue = $this->getAssertionValue();
+
+        [$attribute, $dnAttributes, $matchingRule] = $this->parseExtensibleComponents($token);
+
+        if (null === $attribute && null === $matchingRule) {
+            $this->syntaxError('extensible match requires at least an attribute or a matching rule');
+        }
+
+        return new ExtensibleNode($attribute, $dnAttributes, $matchingRule, $assertionValue);
+    }
+
+    /**
+     * @return array{0: ?string, 1: bool, 2: ?string}
+     */
+    private function parseExtensibleComponents(string $token): array
+    {
+        $parts = explode(':', $token);
+        array_pop($parts); // remove trailing empty element (token always ends with ':')
+
+        $attribute = array_shift($parts) ?: null;
+        $dnAttributes = false;
+        $matchingRule = null;
+
+        foreach ($parts as $part) {
+            if (0 === strcasecmp($part, 'dn')) {
+                $dnAttributes = true;
+            } else {
+                $matchingRule = $part;
+            }
+        }
+
+        return [$attribute, $dnAttributes, $matchingRule];
     }
 
     private function getAttribute(): AttributeNode

--- a/src/Visitor/LdapExpressionVisitor.php
+++ b/src/Visitor/LdapExpressionVisitor.php
@@ -3,6 +3,7 @@
 namespace Jvancoillie\LdapFilterLexer\Visitor;
 
 use Jvancoillie\LdapFilterLexer\AST\AndNode;
+use Jvancoillie\LdapFilterLexer\AST\ExtensibleNode;
 use Jvancoillie\LdapFilterLexer\AST\NotNode;
 use Jvancoillie\LdapFilterLexer\AST\OrNode;
 use Jvancoillie\LdapFilterLexer\AST\SimpleNode;
@@ -42,6 +43,16 @@ class LdapExpressionVisitor implements NodeVisitorInterface
             $node->attribute->value,
             $node->filterType->value,
             $value
+        );
+    }
+
+    public function visitExtensibleNode(ExtensibleNode $node): Expression\ExtensibleMatch
+    {
+        return new Expression\ExtensibleMatch(
+            $node->attribute,
+            $node->dnAttributes,
+            $node->matchingRule,
+            $node->assertionValue->value ?? '',
         );
     }
 }

--- a/src/Visitor/NodeVisitorInterface.php
+++ b/src/Visitor/NodeVisitorInterface.php
@@ -3,6 +3,7 @@
 namespace Jvancoillie\LdapFilterLexer\Visitor;
 
 use Jvancoillie\LdapFilterLexer\AST\AndNode;
+use Jvancoillie\LdapFilterLexer\AST\ExtensibleNode;
 use Jvancoillie\LdapFilterLexer\AST\NotNode;
 use Jvancoillie\LdapFilterLexer\AST\OrNode;
 use Jvancoillie\LdapFilterLexer\AST\SimpleNode;
@@ -31,4 +32,9 @@ interface NodeVisitorInterface
      * @return T
      */
     public function visitSimpleNode(SimpleNode $node): mixed;
+
+    /**
+     * @return T
+     */
+    public function visitExtensibleNode(ExtensibleNode $node): mixed;
 }

--- a/tests/FilterBuilderTest.php
+++ b/tests/FilterBuilderTest.php
@@ -138,4 +138,24 @@ class FilterBuilderTest extends TestCase
 
         FilterBuilder::create()->not();
     }
+
+    /** @dataProvider extensibleProvider */
+    public function testExtensible(string $expected, string $value, ?string $attribute, ?string $matchingRule, bool $dn): void
+    {
+        $filter = FilterBuilder::create()
+            ->extensible($value, $attribute, $matchingRule, $dn)
+            ->getFilter();
+
+        $this->assertSame($expected, (string) $filter);
+    }
+
+    public static function extensibleProvider(): \Generator
+    {
+        yield 'attr only' => ['(cn:=Betty Rubble)', 'Betty Rubble', 'cn', null, false];
+        yield 'attr + matchingRule' => ['(cn:caseExactMatch:=Fred Flintstone)', 'Fred Flintstone', 'cn', 'caseExactMatch', false];
+        yield 'attr + dn' => ['(o:dn:=Ace Industry)', 'Ace Industry', 'o', null, true];
+        yield 'attr + dn + matchingRule' => ['(sn:dn:2.4.6.8.10:=Barney Rubble)', 'Barney Rubble', 'sn', '2.4.6.8.10', true];
+        yield 'matchingRule only' => ['(:1.2.3:=Wilma Flintstone)', 'Wilma Flintstone', null, '1.2.3', false];
+        yield 'AD recursive membership' => ['(member:1.2.840.113556.1.4.1941:=CN=John,DC=example,DC=com)', 'CN=John,DC=example,DC=com', 'member', '1.2.840.113556.1.4.1941', false];
+    }
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -2,6 +2,7 @@
 
 namespace Jvancoillie\LdapFilterLexer\Tests;
 
+use Jvancoillie\LdapFilterLexer\AST\ExtensibleNode;
 use Jvancoillie\LdapFilterLexer\AST\SimpleNode;
 use Jvancoillie\LdapFilterLexer\Filter;
 use Jvancoillie\LdapFilterLexer\FilterException;
@@ -104,5 +105,27 @@ class ParserTest extends TestCase
         yield 'AND with three conditions' => ['(&(cn=a)(sn=b)(uid=c))'];
         yield 'OR with two conditions' => ['(|(cn=a)(sn=b))'];
         yield 'OR with three conditions' => ['(|(cn=a)(sn=b)(uid=c))'];
+    }
+
+    /** @dataProvider extensibleMatchProvider */
+    public function testParserBuildsExtensibleNode(string $filter, ?string $attr, bool $dn, ?string $rule, ?string $value): void
+    {
+        $ast = (new Parser(new Filter($filter)))->getAST();
+
+        $this->assertInstanceOf(ExtensibleNode::class, $ast);
+        $this->assertSame($attr, $ast->attribute);
+        $this->assertSame($dn, $ast->dnAttributes);
+        $this->assertSame($rule, $ast->matchingRule);
+        $this->assertSame($value, $ast->assertionValue->value);
+    }
+
+    public static function extensibleMatchProvider(): \Generator
+    {
+        yield 'attr only' => ['(cn:=Betty Rubble)', 'cn', false, null, 'Betty Rubble'];
+        yield 'attr + matchingRule' => ['(cn:caseExactMatch:=Fred Flintstone)', 'cn', false, 'caseExactMatch', 'Fred Flintstone'];
+        yield 'attr + dn' => ['(o:dn:=Ace Industry)', 'o', true, null, 'Ace Industry'];
+        yield 'attr + dn + matchingRule' => ['(sn:dn:2.4.6.8.10:=Barney Rubble)', 'sn', true, '2.4.6.8.10', 'Barney Rubble'];
+        yield 'matchingRule only' => ['(:1.2.3:=Wilma Flintstone)', null, false, '1.2.3', 'Wilma Flintstone'];
+        yield 'dn + matchingRule' => ['(:DN:2.4.6.8.10:=Dino)', null, true, '2.4.6.8.10', 'Dino'];
     }
 }

--- a/tests/Visitor/LdapExpressionVisitorTest.php
+++ b/tests/Visitor/LdapExpressionVisitorTest.php
@@ -5,6 +5,7 @@ namespace Jvancoillie\LdapFilterLexer\Tests\Visitor;
 use Jvancoillie\LdapFilterLexer\AST\AndNode;
 use Jvancoillie\LdapFilterLexer\AST\AssertionValueNode;
 use Jvancoillie\LdapFilterLexer\AST\AttributeNode;
+use Jvancoillie\LdapFilterLexer\AST\ExtensibleNode;
 use Jvancoillie\LdapFilterLexer\AST\FilterTypeNode;
 use Jvancoillie\LdapFilterLexer\AST\NotNode;
 use Jvancoillie\LdapFilterLexer\AST\OrNode;
@@ -72,5 +73,25 @@ class LdapExpressionVisitorTest extends TestCase
 
         $visitor = new LdapExpressionVisitor();
         $result = $simpleNode->accept($visitor);
+    }
+
+    /** @dataProvider extensibleNodeProvider */
+    public function testVisitExtensibleNode(ExtensibleNode $node, string $expected): void
+    {
+        $visitor = new LdapExpressionVisitor();
+        $result = $node->accept($visitor);
+
+        $this->assertInstanceOf(Expression\ExtensibleMatch::class, $result);
+        $this->assertSame($expected, (string) $result);
+    }
+
+    public static function extensibleNodeProvider(): \Generator
+    {
+        yield 'attr only' => [new ExtensibleNode('cn', false, null, new AssertionValueNode('Betty Rubble')), '(cn:=Betty Rubble)'];
+        yield 'attr + matchingRule' => [new ExtensibleNode('cn', false, 'caseExactMatch', new AssertionValueNode('Fred Flintstone')), '(cn:caseExactMatch:=Fred Flintstone)'];
+        yield 'attr + dn' => [new ExtensibleNode('o', true, null, new AssertionValueNode('Ace Industry')), '(o:dn:=Ace Industry)'];
+        yield 'attr + dn + matchingRule' => [new ExtensibleNode('sn', true, '2.4.6.8.10', new AssertionValueNode('Barney Rubble')), '(sn:dn:2.4.6.8.10:=Barney Rubble)'];
+        yield 'matchingRule only' => [new ExtensibleNode(null, false, '1.2.3', new AssertionValueNode('Wilma Flintstone')), '(:1.2.3:=Wilma Flintstone)'];
+        yield 'dn + matchingRule' => [new ExtensibleNode(null, true, '2.4.6.8.10', new AssertionValueNode('Dino')), '(:dn:2.4.6.8.10:=Dino)'];
     }
 }


### PR DESCRIPTION
Adds full parsing and serialization of extensible match filters:
- ExtensibleNode AST node with attribute, dnAttributes, matchingRule fields
- Expression\ExtensibleMatch for string serialization
- Parser detects ':' in attribute token and routes to parseExtensibleFilter()
- FilterBuilder::extensible() for programmatic construction
- Covers all RFC 4515 forms: attr:=, attr:rule:=, attr:dn:=, :rule:=, :dn:rule:=

Resolves false positives in FilterTest where extensible match filters were accepted by accident (colon treated as part of attribute name).