### PR TITLE
refactor(AST): make all node properties public readonly

### DIFF
--- a/src/AST/AndNode.php
+++ b/src/AST/AndNode.php
@@ -7,13 +7,9 @@ use Jvancoillie\LdapFilterLexer\Visitor\VisitableNodeInterface;
 
 class AndNode extends Node implements VisitableNodeInterface
 {
-    /** @var array<Node> */
-    public array $conditions = [];
-
-    /** @param array<Node> $conditions*/
-    public function __construct(array $conditions = [])
+    /** @param array<Node> $conditions */
+    public function __construct(public readonly array $conditions = [])
     {
-        $this->conditions = $conditions;
     }
 
     public function accept(NodeVisitorInterface $visitor): mixed

--- a/src/AST/AssertionValueNode.php
+++ b/src/AST/AssertionValueNode.php
@@ -4,10 +4,7 @@ namespace Jvancoillie\LdapFilterLexer\AST;
 
 class AssertionValueNode
 {
-    public ?string $value;
-
-    public function __construct(?string $value)
+    public function __construct(public readonly ?string $value)
     {
-        $this->value = $value;
     }
 }

--- a/src/AST/AttributeNode.php
+++ b/src/AST/AttributeNode.php
@@ -4,10 +4,7 @@ namespace Jvancoillie\LdapFilterLexer\AST;
 
 class AttributeNode
 {
-    public string $value;
-
-    public function __construct(string $value)
+    public function __construct(public readonly string $value)
     {
-        $this->value = $value;
     }
 }

--- a/src/AST/FilterTypeNode.php
+++ b/src/AST/FilterTypeNode.php
@@ -4,10 +4,7 @@ namespace Jvancoillie\LdapFilterLexer\AST;
 
 class FilterTypeNode
 {
-    public string $value;
-
-    public function __construct(string $value)
+    public function __construct(public readonly string $value)
     {
-        $this->value = $value;
     }
 }

--- a/src/AST/NotNode.php
+++ b/src/AST/NotNode.php
@@ -7,11 +7,8 @@ use Jvancoillie\LdapFilterLexer\Visitor\VisitableNodeInterface;
 
 class NotNode extends Node implements VisitableNodeInterface
 {
-    public Node $condition;
-
-    public function __construct(Node $condition)
+    public function __construct(public readonly Node $condition)
     {
-        $this->condition = $condition;
     }
 
     public function accept(NodeVisitorInterface $visitor): mixed

--- a/src/AST/OrNode.php
+++ b/src/AST/OrNode.php
@@ -7,13 +7,9 @@ use Jvancoillie\LdapFilterLexer\Visitor\VisitableNodeInterface;
 
 class OrNode extends Node implements VisitableNodeInterface
 {
-    /** @var array<Node> */
-    public array $conditions = [];
-
-    /** @param array<Node> $conditions*/
-    public function __construct(array $conditions = [])
+    /** @param array<Node> $conditions */
+    public function __construct(public readonly array $conditions = [])
     {
-        $this->conditions = $conditions;
     }
 
     public function accept(NodeVisitorInterface $visitor): mixed

--- a/src/AST/SimpleNode.php
+++ b/src/AST/SimpleNode.php
@@ -7,15 +7,11 @@ use Jvancoillie\LdapFilterLexer\Visitor\VisitableNodeInterface;
 
 class SimpleNode extends Node implements VisitableNodeInterface
 {
-    public AttributeNode $attribute;
-    public FilterTypeNode $filterType;
-    public AssertionValueNode $assertionValue;
-
-    public function __construct(AttributeNode $attribute, FilterTypeNode $filterType, AssertionValueNode $assertionValue)
-    {
-        $this->attribute = $attribute;
-        $this->filterType = $filterType;
-        $this->assertionValue = $assertionValue;
+    public function __construct(
+        public readonly AttributeNode $attribute,
+        public readonly FilterTypeNode $filterType,
+        public readonly AssertionValueNode $assertionValue,
+    ) {
     }
 
     public function accept(NodeVisitorInterface $visitor): mixed

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -166,7 +166,8 @@ class Parser
         $parts = explode(':', $token);
         array_pop($parts); // remove trailing empty element (token always ends with ':')
 
-        $attribute = array_shift($parts) ?: null;
+        $firstPart = array_shift($parts);
+        $attribute = (null !== $firstPart && '' !== $firstPart) ? $firstPart : null;
         $dnAttributes = false;
         $matchingRule = null;
 


### PR DESCRIPTION
Replaces mutable public properties with readonly constructor-promoted properties across all AST nodes. Prevents post-construction mutation while keeping direct read access unchanged for consumers and visitors.