### PR TITLE
config(psalm): enable findUnusedCode and include tests/ in analysis

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -5,10 +5,11 @@
     xsi:schemaLocation="https://getpsalm.org/schema/config ./vendor/vimeo/psalm/config.xsd"
     errorLevel="1"
     findUnusedBaselineEntry="true"
-    findUnusedCode="false"
+    findUnusedCode="true"
 >
     <projectFiles>
         <directory name="src" />
+        <directory name="tests" />
         <ignoreFiles>
             <directory name="vendor" />
         </ignoreFiles>
@@ -18,5 +19,10 @@
         <MissingOverrideAttribute errorLevel="suppress" />
         <ClassMustBeFinal errorLevel="suppress" />
         <ImplicitToStringCast errorLevel="suppress" />
+        <UnusedClass>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+        </UnusedClass>
     </issueHandlers>
 </psalm>

--- a/src/FilterBuilder.php
+++ b/src/FilterBuilder.php
@@ -18,9 +18,6 @@ class FilterBuilder
             $filter = new Filter($stringFilter);
             $visitor = new LdapExpressionVisitor();
             $ast = $filter->getParser()->getAST();
-            /**
-             * @var Expression\Base $expression
-             */
             $expression = $ast->accept($visitor);
         }
 

--- a/tests/FilterBuilderTest.php
+++ b/tests/FilterBuilderTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 
 class FilterBuilderTest extends TestCase
 {
-    public function testEquals()
+    public function testEquals(): void
     {
         $filterBuilder = FilterBuilder::create();
 
@@ -17,7 +17,7 @@ class FilterBuilderTest extends TestCase
         $this->assertEquals('(givename=Jensen)', (string) $filter);
     }
 
-    public function testGreaterThan()
+    public function testGreaterThan(): void
     {
         $filterBuilder = FilterBuilder::create();
 
@@ -26,7 +26,7 @@ class FilterBuilderTest extends TestCase
         $this->assertEquals('(age>=30)', (string) $filter);
     }
 
-    public function testLowerThan()
+    public function testLowerThan(): void
     {
         $filterBuilder = FilterBuilder::create();
 
@@ -35,7 +35,7 @@ class FilterBuilderTest extends TestCase
         $this->assertEquals('(age<=30)', (string) $filter);
     }
 
-    public function testApproximate()
+    public function testApproximate(): void
     {
         $filterBuilder = FilterBuilder::create();
 
@@ -44,7 +44,7 @@ class FilterBuilderTest extends TestCase
         $this->assertEquals('(email~=example@domain.com)', (string) $filter);
     }
 
-    public function testAndX()
+    public function testAndX(): void
     {
         $filterBuilder = FilterBuilder::create();
 
@@ -56,7 +56,7 @@ class FilterBuilderTest extends TestCase
         $this->assertEquals('(&(givename=Jensen)(uid=bJensen))', (string) $filter);
     }
 
-    public function testOrX()
+    public function testOrX(): void
     {
         $filterBuilder = FilterBuilder::create();
 
@@ -68,7 +68,7 @@ class FilterBuilderTest extends TestCase
         $this->assertEquals('(|(givename=Jensen)(uid=bJensen))', (string) $filter);
     }
 
-    public function testNot()
+    public function testNot(): void
     {
         $filterBuilder = FilterBuilder::create();
 
@@ -77,7 +77,7 @@ class FilterBuilderTest extends TestCase
         $this->assertEquals('(!(uid=bJensen))', (string) $filter);
     }
 
-    public function testCreateWithStringFilter()
+    public function testCreateWithStringFilter(): void
     {
         $stringFilter = '(cn=John Doe)';
 
@@ -91,7 +91,7 @@ class FilterBuilderTest extends TestCase
         $this->assertInstanceOf(Expression\Comparison::class, $expression);
     }
 
-    public function testInvalidArgumentExceptionOnNullExpression()
+    public function testInvalidArgumentExceptionOnNullExpression(): void
     {
         $this->expectException(\InvalidArgumentException::class);
 

--- a/tests/FilterTest.php
+++ b/tests/FilterTest.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
 class FilterTest extends TestCase
 {
     /** @dataProvider  validFilters */
-    public function testFilterIsValid(string $filter)
+    public function testFilterIsValid(string $filter): void
     {
         $filter = new Filter($filter);
 

--- a/tests/LexerTest.php
+++ b/tests/LexerTest.php
@@ -2,6 +2,7 @@
 
 namespace Jvancoillie\LdapFilterLexer\Tests;
 
+use Doctrine\Common\Lexer\AbstractLexer;
 use Jvancoillie\LdapFilterLexer\Lexer;
 use PHPUnit\Framework\TestCase;
 
@@ -11,7 +12,7 @@ class LexerTest extends TestCase
     {
         $lexer = new Lexer('test extend');
 
-        $this->assertInstanceOf('Doctrine\Common\Lexer\AbstractLexer', $lexer);
+        $this->assertInstanceOf(AbstractLexer::class, $lexer);
     }
 
     /** @return iterable<string, array{string, string, string}> */

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -11,16 +11,14 @@ use PHPUnit\Framework\TestCase;
 
 class ParserTest extends TestCase
 {
-    public function testParserReturnAst()
+    public function testParserReturnAst(): void
     {
         $parser = new Parser(new Filter('(&(objectClass=person)(|(sn=*jdoe*)(givenname=*jdoe*)))'));
 
-        $ast = $parser->getAST();
-
-        $this->assertNotNull($ast);
+        $this->assertInstanceOf(\Jvancoillie\LdapFilterLexer\AST\Node::class, $parser->getAST());
     }
 
-    public function testParserThrowExceptionOnSimpleFilterWithoutFilterType()
+    public function testParserThrowExceptionOnSimpleFilterWithoutFilterType(): void
     {
         $this->expectException(FilterException::class);
         $this->expectExceptionMessage("[Syntax Error] line 0, col 9: Error: Expected filter type (~=, =, <=, >=), got ')' on query '(sn*jdoe*)'");
@@ -29,7 +27,7 @@ class ParserTest extends TestCase
         $parser->getAST();
     }
 
-    public function testParserThrowExceptionOnNotFilterWithMultipleSimpleFilter()
+    public function testParserThrowExceptionOnNotFilterWithMultipleSimpleFilter(): void
     {
         $this->expectException(FilterException::class);
         $this->expectExceptionMessage("[Syntax Error] line 0, col 12: Error: Expected ), got '(' on query '(!(cn=john*)(cn=doe*)'");
@@ -94,9 +92,7 @@ class ParserTest extends TestCase
     /** @dataProvider validMultipleConditionsProvider */
     public function testParserAcceptsAndOrWithTwoOrMoreConditions(string $filter): void
     {
-        $ast = (new Parser(new Filter($filter)))->getAST();
-
-        $this->assertNotNull($ast);
+        $this->assertInstanceOf(\Jvancoillie\LdapFilterLexer\AST\Node::class, (new Parser(new Filter($filter)))->getAST());
     }
 
     public static function validMultipleConditionsProvider(): \Generator

--- a/tests/Visitor/LdapExpressionVisitorTest.php
+++ b/tests/Visitor/LdapExpressionVisitorTest.php
@@ -17,7 +17,7 @@ use PHPUnit\Framework\TestCase;
 
 class LdapExpressionVisitorTest extends TestCase
 {
-    public function testVisitAndNode()
+    public function testVisitAndNode(): void
     {
         $andNode = new AndNode([
             new SimpleNode(new AttributeNode('attr1'), new FilterTypeNode(Lexer::EQUALS), new AssertionValueNode('value1')),
@@ -31,7 +31,7 @@ class LdapExpressionVisitorTest extends TestCase
         $this->assertSame('(&(attr1=value1)(attr2=value2))', (string) $result);
     }
 
-    public function testVisitOrNode()
+    public function testVisitOrNode(): void
     {
         $orNode = new OrNode([
             new SimpleNode(new AttributeNode('attr1'), new FilterTypeNode(Lexer::EQUALS), new AssertionValueNode('value1')),
@@ -45,7 +45,7 @@ class LdapExpressionVisitorTest extends TestCase
         $this->assertSame('(|(attr1=value1)(attr2=value2))', (string) $result);
     }
 
-    public function testVisitNotNode()
+    public function testVisitNotNode(): void
     {
         $notNode = new NotNode(new SimpleNode(new AttributeNode('attr1'), new FilterTypeNode(Lexer::EQUALS), new AssertionValueNode('value1')));
 
@@ -55,7 +55,7 @@ class LdapExpressionVisitorTest extends TestCase
         $this->assertInstanceOf(Expression\Not::class, $result);
     }
 
-    public function testVisitSimpleNode()
+    public function testVisitSimpleNode(): void
     {
         $simpleNode = new SimpleNode(new AttributeNode('attr1'), new FilterTypeNode(Lexer::EQUALS), new AssertionValueNode('value1'));
 
@@ -66,13 +66,13 @@ class LdapExpressionVisitorTest extends TestCase
         $this->assertSame('(attr1=value1)', (string) $result);
     }
 
-    public function testVisitSimpleNodeThrowExceptionOnEmptyAssertionValue()
+    public function testVisitSimpleNodeThrowExceptionOnEmptyAssertionValue(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $simpleNode = new SimpleNode(new AttributeNode('attr1'), new FilterTypeNode(Lexer::EQUALS), new AssertionValueNode(null));
 
         $visitor = new LdapExpressionVisitor();
-        $result = $simpleNode->accept($visitor);
+        $simpleNode->accept($visitor);
     }
 
     /** @dataProvider extensibleNodeProvider */


### PR DESCRIPTION
Activates findUnusedCode="true" so dead code is caught early. Adds tests/ to projectFiles so public API methods are recognised as used. Suppresses UnusedClass in tests/ (PHPUnit discovers classes by reflection). Also fixes all issues surfaced: MissingReturnType on legacy test methods, UnnecessaryVarAnnotation in FilterBuilder, RedundantCondition in ParserTest, UnusedVariable in LdapExpressionVisitorTest, and ArgumentTypeCoercion in LexerTest (string literal → AbstractLexer::class).