### PR TITLE
config(phpunit): enable failOnRisky and failOnWarning

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,9 +4,9 @@
          bootstrap="vendor/autoload.php"
          colors="true"
          executionOrder="defects"
+         failOnRisky="true"
+         failOnWarning="true"
 >
-    <coverage/>
-
     <testsuites>
         <testsuite name="LdapFilterLexer Test Suite">
             <directory>./tests</directory>


### PR DESCRIPTION
Tests without assertions or with ambiguous coverage metadata now fail the build. The <coverage/> placeholder is removed — coverage reports are generated on demand via XDEBUG_MODE=coverage vendor/bin/phpunit with the --coverage-text / --coverage-clover flags.